### PR TITLE
Configurable thermal limit and pass minimum elevation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ a set of mandatory configuration keys:
 #### [Main]
 General operation settings.
 * `satellite` (String, optional) - Default satellite ID, either index into TleCache or NORAD ID.
+* `minimum-pass-elevation` (Float or Integer, optional) - Minimum elevation that `satellite` must
+  rise above to be considered for a pass. Default: 15°
 * `owmid` (String, optional) - An API key from [OpenWeatherMap API](https://openweathermap.org/api)
 * `edl_port` (int, optional) - Port to listen for
   [EDL commands](https://oresat-c3-software.readthedocs.io/en/latest/edl.html).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Physical properties of the ground station.
 * `lon` (Float or Integer) - Station longitude in decimal notation.
 * `alt` (Integer) - Station altitude in meters.
 * `name` (String) - station name or callsign.
+* `temperature-limit` (Float or Integer, optional) - Temperature in Celsius above which stops a
+  pass from being run to protect the hardware. Default: 40°C
 
 #### [TleCache]
 Optional local cache of TLEs. Currently only 3 line TLEs are supported. Format

--- a/pass_commander/commander.py
+++ b/pass_commander/commander.py
@@ -287,9 +287,6 @@ class Commander:
         '''Create the main pass coordinator.'''
         self.conf = conf
         self.track = Tracker(conf.observer, owmid=conf.owmid)
-
-        # FIXME: should this go in config?
-        self.min_el = Angle(degrees=15)
         self.singlepass = SinglePass(conf)
 
     def require_clock_sync(self) -> None:
@@ -327,7 +324,7 @@ class Commander:
             sat = Satellite(
                 self.conf.sat_id, tle_cache=self.conf.tle_cache, local_only='con' in self.conf.mock
             )
-            np = self.track.next_pass(sat, min_el=self.min_el)
+            np = self.track.next_pass(sat, min_el=self.conf.min_el)
             if np is None:
                 # FIXME: sleep until next TLE?
                 raise RuntimeError("No pass found")

--- a/pass_commander/commander.py
+++ b/pass_commander/commander.py
@@ -288,8 +288,7 @@ class Commander:
         self.conf = conf
         self.track = Tracker(conf.observer, owmid=conf.owmid)
 
-        # FIXME: should these go in config?
-        self.max_temp = 30.0
+        # FIXME: should this go in config?
         self.min_el = Angle(degrees=15)
         self.singlepass = SinglePass(conf)
 
@@ -363,11 +362,13 @@ class Commander:
             sat, np = self.sleep_until_next_pass()
 
             degc = self.singlepass.sta.gettemp()
-            if degc > self.max_temp:
+            # FIXME: Should temperature be monitored during the pass as well? Should stationd send
+            #        a warning event?
+            if degc > self.conf.temp_limit:
                 logger.info(
                     "Temperature is too high (%f°C > %f°C). Skipping this pass.",
                     degc,
-                    self.max_temp,
+                    self.conf.temp_limit,
                 )
             else:
                 # Pre-compute pass time/alt/az/rv

--- a/pass_commander/config.py
+++ b/pass_commander/config.py
@@ -9,6 +9,7 @@ import tomlkit
 from sgp4 import earth_gravity, io
 from skyfield.api import E, N, wgs84
 from skyfield.toposlib import GeographicPosition
+from skyfield.units import Angle
 from tomlkit.items import Table
 from tomlkit.toml_document import TOMLDocument
 
@@ -140,6 +141,7 @@ class Config:
 
     # Main
     sat_id: str = ''
+    min_el: Angle = Angle(degrees=15.0)  # noqa: RUF009 __post_init__ will create a copy
     owmid: str = ''
     edl: tuple[str, int] = ('', 10025)
     txgain: int = 2
@@ -199,6 +201,7 @@ class Config:
 
         main = _pop_table(config, 'Main')
         self.sat_id = str(_pop(main, 'satellite', str, self.sat_id))
+        self.min_el = Angle(degrees=_pop(main, 'minimum-pass-elevation', Real, self.min_el.degrees))
         self.owmid = str(_pop(main, 'owmid', str, self.owmid))
         self.edl = ('', int(_pop(main, 'edl_port', int, self.edl[1])))
         self.txgain = int(_pop(main, 'txgain', int))

--- a/pass_commander/config.py
+++ b/pass_commander/config.py
@@ -157,6 +157,9 @@ class Config:
     cal: AzEl = AzEl(0, 0)
     slew: AzEl | None = None
     beam_width: float | None = None
+    # FIXME: the limit should be retrieved from stationd instead of our toml but that feature
+    #        doesn't exist.
+    temp_limit: float = 40.0
 
     # Satellite
     tle_cache: TleCache = field(default_factory=dict)
@@ -221,6 +224,7 @@ class Config:
                 observer.display_name, 'lon', self.observer.longitude.degrees
             )
         self.name = str(_pop(observer, 'name', str))  # XMLRPC can't handle toml subclass
+        self.temp_limit = float(_pop(observer, 'temperature-limit', Real, self.temp_limit))
 
         self.tle_cache = dict(_pop_table(config, 'TleCache', {}))
         # validate TLEs

--- a/pass_commander/main.py
+++ b/pass_commander/main.py
@@ -89,6 +89,11 @@ def handle_args() -> Namespace:  # noqa: D103
         action="count",
         help="Output additional debugging information",
     )
+    parser.add_argument(
+        "--temperature-limit",
+        type=float,
+        help="Temperature in Celsius of the station above which prevents a pass from running",
+    )
     return parser.parse_args()
 
 
@@ -152,6 +157,7 @@ def main() -> None:  # noqa: D103 C901 PLR0912 PLR0915
             )
             return
         conf.pass_count = args.pass_count
+        conf.temp_limit = args.temperature_limit or conf.temp_limit
 
         mock_edl = None
         mock_flowgraph = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def good_toml() -> TOMLDocument:
     observer['lon'] = -122.681394
     observer['alt'] = 500
     observer['name'] = 'not-real'
+    observer['temperature-limit'] = 33.0
 
     cfg['Main'] = main
     cfg['Hosts'] = hosts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def good_toml() -> TOMLDocument:
 
     main = tomlkit.table()
     main['satellite'] = "fake-sat"
+    main['minimum-pass-elevation'] = 16
     main['owmid'] = "fake-id"
     main['edl_port'] = 12345
     main['txgain'] = 47

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ class TestConfig:
         assert conf.observer.latitude.degrees == good_toml['Observer']['lat']
         assert conf.observer.longitude.degrees == good_toml['Observer']['lon']
         assert conf.observer.elevation.m == good_toml['Observer']['alt']
+        assert conf.temp_limit == good_toml['Observer']['temperature-limit']
         assert conf.name == good_toml['Observer']['name']
         for field in dataclasses.fields(conf):
             # The toml string class, a subclass of str, was leaking through conf
@@ -42,11 +43,12 @@ class TestConfig:
             )
         assert set(conf.tle_cache) == set(good_toml['TleCache'])
 
-        # satellite, owmid, edl_port, TleCache is optional
+        # satellite, owmid, edl_port, temperature-limit, TleCache is optional
         del good_toml['Main']['satellite']
         del good_toml['Main']['owmid']
         del good_toml['Main']['edl_port']
         del good_toml['TleCache']
+        del good_toml['Observer']['temperature-limit']
         path = tmp_path / 'optional.toml'
         with path.open('w+') as f:
             tomlkit.dump(good_toml, f)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ class TestConfig:
             f.flush()
         conf = Config(path)
         assert conf.sat_id == good_toml['Main']['satellite']
+        assert conf.min_el.degrees == good_toml['Main']['minimum-pass-elevation']
         assert conf.owmid == good_toml['Main']['owmid']
         assert conf.edl == ("", good_toml['Main']['edl_port'])
         assert conf.txgain == good_toml['Main']['txgain']
@@ -43,8 +44,10 @@ class TestConfig:
             )
         assert set(conf.tle_cache) == set(good_toml['TleCache'])
 
-        # satellite, owmid, edl_port, temperature-limit, TleCache is optional
+        # satellite, minimum-pass-elevation, owmid, edl_port, temperature-limit, TleCache are
+        # optional
         del good_toml['Main']['satellite']
+        del good_toml['Main']['minimum-pass-elevation']
         del good_toml['Main']['owmid']
         del good_toml['Main']['edl_port']
         del good_toml['TleCache']


### PR DESCRIPTION
As demonstrated a couple weeks ago and identified in the previous review, the limit for temperature at which pass-commander refuses to start a pass should be configurable, either for setting general policy from the config or quick operator override from the command line. While writing this I realized that stationd should probably be the one to know about the thermal limits of the station it's operating on and inform pass commander of it but that feature isn't implemented yet there so this is a good interim. 

While I was there I also made minimum pass elevation a config option, while ideally we'd like to consider down to 15 degrees, currently we're only interested in passes above 45 degrees.