### PR TITLE
Add pointing mode

### DIFF
--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -1,8 +1,10 @@
 # ruff: noqa: ERA001
 
 import pytest
+from skyfield.api import E, N, Time, wgs84
+from skyfield.units import Angle, Velocity
 
-from pass_commander.commander import SinglePass
+from pass_commander.commander import Commander, SinglePass
 from pass_commander.config import Config
 from pass_commander.mock.flowgraph import Edl, Flowgraph
 from pass_commander.mock.rotator import PtyRotator
@@ -11,22 +13,23 @@ from pass_commander.satellite import Satellite
 from pass_commander.tracker import Tracker
 
 
-class TestSinglePass:
-    @pytest.fixture
-    def mock_config(
-        self,
-        good_config: Config,
-        stationd: Stationd,
-        rotator: PtyRotator,
-        edl: Edl,
-        flowgraph: Flowgraph,
-    ) -> Config:
-        good_config.station = stationd
-        good_config.rotator = rotator
-        good_config.edl_dest = edl.addr
-        good_config.flowgraph = flowgraph.addr
-        return good_config
+@pytest.fixture
+def mock_config(
+    good_config: Config,
+    stationd: Stationd,
+    rotator: PtyRotator,
+    edl: Edl,
+    flowgraph: Flowgraph,
+) -> Config:
+    '''Generate a config with all mock devices started.'''
+    good_config.station = stationd
+    good_config.rotator = rotator
+    good_config.edl_dest = edl.addr
+    good_config.flowgraph = flowgraph.addr
+    return good_config
 
+
+class TestSinglePass:
     def test_work_pass(self, mock_config: Config, sat: Satellite) -> None:
         sp = SinglePass(mock_config, lna_delay=0.0, morse_delay=0.0, cooloff_delay=0.0)
         sp.rot.cmd_interval = 0
@@ -59,3 +62,38 @@ class TestSinglePass:
         rt += 1000
         with pytest.raises(RuntimeError, match="^Temperature too high"):
             sp.work((pt, az, el), (pt, az, el), (rt, rv))
+
+
+class TestCommander:
+    def test_pointing_mode(self, mock_config: Config) -> None:
+        class FakePass:
+            def work(
+                self,
+                _pos: tuple[Time, Angle, Angle],
+                nav: tuple[Time, Angle, Angle],
+                _rv: tuple[Time, Velocity],
+            ) -> None:
+                self.target_az = nav[1].degrees[0]
+
+        origin = wgs84.latlon(45 * N, -122 * E)
+        mock_config.observer = origin
+
+        cmdr = Commander(mock_config)
+        cmdr.singlepass = FakePass()
+
+        lat = origin.latitude.degrees
+        lon = origin.longitude.degrees
+
+        targets = [
+            (wgs84.latlon(lat + 0.1, lon + 0.0), 0),  # North
+            (wgs84.latlon(lat + 0.1, lon + 0.1), 45),  # NE
+            (wgs84.latlon(lat + 0.1, lon - 0.1), 315),  # NW
+            (wgs84.latlon(lat - 0.1, lon + 0.0), 180),  # South
+            (wgs84.latlon(lat - 0.1, lon + 0.1), 135),  # SE
+            (wgs84.latlon(lat - 0.1, lon - 0.1), 225),  # SW
+            (wgs84.latlon(lat + 0.0, lon + 0.1), 90),  # East
+            (wgs84.latlon(lat + 0.0, lon - 0.1), 270),  # West
+        ]
+        for target, expected_az in targets:
+            cmdr.point(target)
+            assert cmdr.singlepass.target_az == pytest.approx(expected_az)


### PR DESCRIPTION
This is a testing feature, the intent is someone on the ground with an engineering unit satellite to go to a specific location and communicate that coordinate to the station operator. This will point the antenna at that coordinate and then run all the actions for a normal pass but indefinitely until the operator stops operation with ctrl+c. Conflicts with normal operation but it's not yet enforced in the command line invocation.